### PR TITLE
Rating system backend change for scenes

### DIFF
--- a/graphql/schema/types/config.graphql
+++ b/graphql/schema/types/config.graphql
@@ -223,7 +223,6 @@ enum RatingSystem {
   TenPointFiveStar
   TenPointTwoFiveStar
   TenPointDecimal
-  None
 }
 
 input ConfigImageLightboxInput {

--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -135,7 +135,9 @@ input SceneFilterType {
   """Filter by file count"""
   file_count: IntCriterionInput
   """Filter by rating"""
-  rating: IntCriterionInput
+  rating: IntCriterionInput @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: IntCriterionInput
   """Filter by organized"""
   organized: Boolean
   """Filter by o-counter"""

--- a/graphql/schema/types/scene.graphql
+++ b/graphql/schema/types/scene.graphql
@@ -40,7 +40,10 @@ type Scene {
   details: String
   url: String
   date: String
-  rating: Int
+  # rating expressed as 1-5
+  rating: Int @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: Int
   organized: Boolean!
   o_counter: Int
   path: String! @deprecated(reason: "Use files.path")
@@ -80,7 +83,10 @@ input SceneUpdateInput {
   details: String
   url: String
   date: String
-  rating: Int
+  # rating expressed as 1-5
+  rating: Int @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: Int
   organized: Boolean
   studio_id: ID
   gallery_ids: [ID!]
@@ -110,7 +116,10 @@ input BulkSceneUpdateInput {
   details: String
   url: String
   date: String
-  rating: Int
+  # rating expressed as 1-5
+  rating: Int @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: Int
   organized: Boolean
   studio_id: ID
   gallery_ids: BulkUpdateIds
@@ -158,7 +167,10 @@ type SceneParserResult {
   details: String
   url: String
   date: String
-  rating: Int
+  # rating expressed as 1-5
+  rating: Int @deprecated(reason: "Use 1-100 range with rating100")
+  # rating expressed as 1-100
+  rating100: Int
   studio_id: ID
   gallery_ids: [ID!]
   performer_ids: [ID!]

--- a/internal/api/resolver_mutation_scene.go
+++ b/internal/api/resolver_mutation_scene.go
@@ -104,6 +104,7 @@ func (r *mutationResolver) sceneUpdate(ctx context.Context, input models.SceneUp
 	updatedScene.URL = translator.optionalString(input.URL, "url")
 	updatedScene.Date = translator.optionalDate(input.Date, "date")
 	updatedScene.Rating = translator.optionalInt(input.Rating, "rating")
+	updatedScene.Rating100 = translator.optionalInt(input.Rating100, "rating100")
 	updatedScene.StudioID, err = translator.optionalIntFromString(input.StudioID, "studio_id")
 	if err != nil {
 		return nil, fmt.Errorf("converting studio id: %w", err)
@@ -199,6 +200,7 @@ func (r *mutationResolver) BulkSceneUpdate(ctx context.Context, input BulkSceneU
 	updatedScene.URL = translator.optionalString(input.URL, "url")
 	updatedScene.Date = translator.optionalDate(input.Date, "date")
 	updatedScene.Rating = translator.optionalInt(input.Rating, "rating")
+	updatedScene.Rating100 = translator.optionalInt(input.Rating100, "rating100")
 	updatedScene.StudioID, err = translator.optionalIntFromString(input.StudioID, "studio_id")
 	if err != nil {
 		return nil, fmt.Errorf("converting studio id: %w", err)

--- a/internal/manager/filename_parser.go
+++ b/internal/manager/filename_parser.go
@@ -112,6 +112,7 @@ func initParserFields() {
 
 	ret["d"] = newParserField("d", `(?:\.|-|_)`, false)
 	ret["rating"] = newParserField("rating", `\d`, true)
+	ret["rating100"] = newParserField("rating100", `\d`, true)
 	ret["performer"] = newParserField("performer", ".*", true)
 	ret["studio"] = newParserField("studio", ".*", true)
 	ret["movie"] = newParserField("movie", ".*", true)
@@ -255,6 +256,10 @@ func validateRating(rating int) bool {
 	return rating >= 1 && rating <= 5
 }
 
+func validateRating100(rating100 int) bool {
+	return rating100 >= 1 && rating100 <= 100
+}
+
 func validateDate(dateStr string) bool {
 	splits := strings.Split(dateStr, "-")
 	if len(splits) != 3 {
@@ -347,6 +352,11 @@ func (h *sceneHolder) setField(field parserField, value interface{}) {
 		rating, _ := strconv.Atoi(value.(string))
 		if validateRating(rating) {
 			h.result.Rating = &rating
+		}
+	case "rating100":
+		rating, _ := strconv.Atoi(value.(string))
+		if validateRating100(rating) {
+			h.result.Rating100 = &rating
 		}
 	case "performer":
 		// add performer to list
@@ -704,6 +714,9 @@ func (p *SceneFilenameParser) setParserResult(ctx context.Context, repo SceneFil
 
 	if h.result.Rating != nil {
 		result.Rating = h.result.Rating
+	}
+	if h.result.Rating100 != nil {
+		result.Rating100 = h.result.Rating100
 	}
 
 	if len(h.performers) > 0 {

--- a/internal/manager/filename_parser.go
+++ b/internal/manager/filename_parser.go
@@ -30,6 +30,7 @@ type SceneParserResult struct {
 	URL          *string         `json:"url"`
 	Date         *string         `json:"date"`
 	Rating       *int            `json:"rating"`
+	Rating100    *int            `json:"rating100"`
 	StudioID     *string         `json:"studio_id"`
 	GalleryIds   []string        `json:"gallery_ids"`
 	PerformerIds []string        `json:"performer_ids"`

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -18,6 +18,7 @@ type Scene struct {
 	URL       string `json:"url"`
 	Date      *Date  `json:"date"`
 	Rating    *int   `json:"rating"`
+	Rating100 *int   `json:"rating100"`
 	Organized bool   `json:"organized"`
 	OCounter  int    `json:"o_counter"`
 	StudioID  *int   `json:"studio_id"`
@@ -137,6 +138,7 @@ type ScenePartial struct {
 	URL       OptionalString
 	Date      OptionalDate
 	Rating    OptionalInt
+	Rating100 OptionalInt
 	Organized OptionalBool
 	OCounter  OptionalInt
 	StudioID  OptionalInt
@@ -171,6 +173,7 @@ type SceneUpdateInput struct {
 	URL              *string            `json:"url"`
 	Date             *string            `json:"date"`
 	Rating           *int               `json:"rating"`
+	Rating100        *int               `json:"rating100"`
 	Organized        *bool              `json:"organized"`
 	StudioID         *string            `json:"studio_id"`
 	GalleryIds       []string           `json:"gallery_ids"`
@@ -197,12 +200,13 @@ func (s ScenePartial) UpdateInput(id int) SceneUpdateInput {
 	}
 
 	return SceneUpdateInput{
-		ID:           strconv.Itoa(id),
-		Title:        s.Title.Ptr(),
-		Details:      s.Details.Ptr(),
-		URL:          s.URL.Ptr(),
-		Date:         dateStr,
-		Rating:       s.Rating.Ptr(),
+		ID:      strconv.Itoa(id),
+		Title:   s.Title.Ptr(),
+		Details: s.Details.Ptr(),
+		URL:     s.URL.Ptr(),
+		Date:    dateStr,
+		Rating:  s.Rating.Ptr(),
+		// TODO Rating100
 		Organized:    s.Organized.Ptr(),
 		StudioID:     s.StudioID.StringPtr(),
 		GalleryIds:   s.GalleryIDs.IDStrings(),

--- a/pkg/models/rating.go
+++ b/pkg/models/rating.go
@@ -3,6 +3,7 @@ package models
 import (
 	"fmt"
 	"io"
+	"math"
 	"strconv"
 )
 
@@ -45,4 +46,23 @@ func (e *RatingSystem) UnmarshalGQL(v interface{}) error {
 
 func (e RatingSystem) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+const (
+	maxRating100 = 100
+	maxRating5   = 5
+	minRating5   = 1
+	minRating100 = 20
+)
+
+// Rating100To5 converts a 1-100 rating to a 1-5 rating.
+// Values <= 30 are converted to 1. Otherwise, rating is divided by 20 and rounded to the nearest integer.
+func Rating100To5(rating100 int) int {
+	val := math.Round((float64(rating100) / 20))
+	return int(math.Max(minRating5, math.Min(maxRating5, val)))
+}
+
+// Rating5To100 converts a 1-5 rating to a 1-100 rating
+func Rating5To100(rating5 int) int {
+	return int(math.Max(minRating100, math.Min(maxRating100, float64(rating5*20))))
 }

--- a/pkg/models/rating_system.go
+++ b/pkg/models/rating_system.go
@@ -9,24 +9,22 @@ import (
 type RatingSystem string
 
 const (
-	FiveStar = "FiveStar"
-	FivePointFiveStar = "FivePointFiveStar"
+	FiveStar             = "FiveStar"
+	FivePointFiveStar    = "FivePointFiveStar"
 	FivePointTwoFiveStar = "FivePointTwoFiveStar"
-	TenStar = "TenStar"
-	TenPointFiveStar = "TenPointFiveStar"
-	TenPointTwoFiveStar = "TenPointTwoFiveStar"
-	TenPointDecimal = "TenPointDecimal"
-	None = "None"
+	TenStar              = "TenStar"
+	TenPointFiveStar     = "TenPointFiveStar"
+	TenPointTwoFiveStar  = "TenPointTwoFiveStar"
+	TenPointDecimal      = "TenPointDecimal"
 )
 
 func (e RatingSystem) IsValid() bool {
 	switch e {
-	case FiveStar, FivePointFiveStar, FivePointTwoFiveStar, TenStar, TenPointFiveStar, TenPointTwoFiveStar, TenPointDecimal, None:
+	case FiveStar, FivePointFiveStar, FivePointTwoFiveStar, TenStar, TenPointFiveStar, TenPointTwoFiveStar, TenPointDecimal:
 		return true
 	}
 	return false
 }
-
 
 func (e RatingSystem) String() string {
 	return string(e)

--- a/pkg/models/rating_test.go
+++ b/pkg/models/rating_test.go
@@ -1,0 +1,55 @@
+package models
+
+import (
+	"testing"
+)
+
+func TestRating100To5(t *testing.T) {
+	tests := []struct {
+		name      string
+		rating100 int
+		want      int
+	}{
+		{"20", 20, 1},
+		{"100", 100, 5},
+		{"1", 1, 1},
+		{"10", 10, 1},
+		{"11", 11, 1},
+		{"21", 21, 1},
+		{"31", 31, 2},
+		{"0", 0, 1},
+		{"-100", -100, 1},
+		{"120", 120, 5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Rating100To5(tt.rating100); got != tt.want {
+				t.Errorf("Rating100To5() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRating5To100(t *testing.T) {
+	tests := []struct {
+		name    string
+		rating5 int
+		want    int
+	}{
+		{"1", 1, 20},
+		{"5", 5, 100},
+		{"2", 2, 40},
+		{"3", 3, 60},
+		{"4", 4, 80},
+		{"6", 6, 100},
+		{"0", 0, 20},
+		{"-1", -1, 20},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Rating5To100(tt.rating5); got != tt.want {
+				t.Errorf("Rating5To100() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/models/scene.go
+++ b/pkg/models/scene.go
@@ -28,8 +28,10 @@ type SceneFilterType struct {
 	Path *StringCriterionInput `json:"path"`
 	// Filter by file count
 	FileCount *IntCriterionInput `json:"file_count"`
-	// Filter by rating
+	// Filter by rating expressed as 1-5
 	Rating *IntCriterionInput `json:"rating"`
+	// Filter by rating expressed as 1-100
+	Rating100 *IntCriterionInput `json:"rating100"`
 	// Filter by organized
 	Organized *bool `json:"organized"`
 	// Filter by o-counter

--- a/pkg/sqlite/filter.go
+++ b/pkg/sqlite/filter.go
@@ -575,6 +575,25 @@ func boolCriterionHandler(c *bool, column string, addJoinFn func(f *filterBuilde
 	}
 }
 
+func rating5CriterionHandler(c *models.IntCriterionInput, column string, addJoinFn func(f *filterBuilder)) criterionHandlerFunc {
+	return func(ctx context.Context, f *filterBuilder) {
+		if c != nil {
+			// make a copy so we can adjust it
+			cc := *c
+			if cc.Value != 0 {
+				cc.Value = models.Rating5To100(cc.Value)
+			}
+			if cc.Value2 != nil {
+				val := models.Rating5To100(*cc.Value2)
+				cc.Value2 = &val
+			}
+
+			clause, args := getIntCriterionWhereClause(column, cc)
+			f.addWhere(clause, args...)
+		}
+	}
+}
+
 // handle for MultiCriterion where there is a join table between the new
 // objects
 type joinedMultiCriterionHandlerBuilder struct {

--- a/pkg/sqlite/scene_test.go
+++ b/pkg/sqlite/scene_test.go
@@ -76,6 +76,7 @@ func Test_sceneQueryBuilder_Create(t *testing.T) {
 		details     = "details"
 		url         = "url"
 		rating      = 3
+		rating100   = 60
 		ocounter    = 5
 		createdAt   = time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC)
 		updatedAt   = time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -104,6 +105,7 @@ func Test_sceneQueryBuilder_Create(t *testing.T) {
 				URL:          url,
 				Date:         &date,
 				Rating:       &rating,
+				Rating100:    &rating100,
 				Organized:    true,
 				OCounter:     ocounter,
 				StudioID:     &studioIDs[studioIdxWithScene],
@@ -143,6 +145,7 @@ func Test_sceneQueryBuilder_Create(t *testing.T) {
 				URL:       url,
 				Date:      &date,
 				Rating:    &rating,
+				Rating100: &rating100,
 				Organized: true,
 				OCounter:  ocounter,
 				StudioID:  &studioIDs[studioIdxWithScene],
@@ -297,6 +300,7 @@ func Test_sceneQueryBuilder_Update(t *testing.T) {
 		details     = "details"
 		url         = "url"
 		rating      = 3
+		rating100   = 60
 		ocounter    = 5
 		createdAt   = time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC)
 		updatedAt   = time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -324,6 +328,7 @@ func Test_sceneQueryBuilder_Update(t *testing.T) {
 				URL:          url,
 				Date:         &date,
 				Rating:       &rating,
+				Rating100:    &rating100,
 				Organized:    true,
 				OCounter:     ocounter,
 				StudioID:     &studioIDs[studioIdxWithScene],
@@ -499,6 +504,7 @@ func Test_sceneQueryBuilder_UpdatePartial(t *testing.T) {
 		details     = "details"
 		url         = "url"
 		rating      = 3
+		rating100   = 60
 		ocounter    = 5
 		createdAt   = time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC)
 		updatedAt   = time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -582,6 +588,7 @@ func Test_sceneQueryBuilder_UpdatePartial(t *testing.T) {
 				URL:          url,
 				Date:         &date,
 				Rating:       &rating,
+				Rating100:    &rating100,
 				Organized:    true,
 				OCounter:     ocounter,
 				StudioID:     &studioIDs[studioIdxWithScene],
@@ -2331,7 +2338,7 @@ func TestSceneQueryPathAndRating(t *testing.T) {
 			Modifier: models.CriterionModifierEquals,
 		},
 		And: &models.SceneFilterType{
-			Rating: &models.IntCriterionInput{
+			Rating100: &models.IntCriterionInput{
 				Value:    sceneRating,
 				Modifier: models.CriterionModifierEquals,
 			},
@@ -2347,7 +2354,7 @@ func TestSceneQueryPathAndRating(t *testing.T) {
 			return nil
 		}
 		assert.Equal(t, scenePath, scenes[0].Path)
-		assert.Equal(t, sceneRating, *scenes[0].Rating)
+		assert.Equal(t, sceneRating, *scenes[0].Rating100)
 
 		return nil
 	})

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -823,7 +823,7 @@ func getSceneTitle(index int) string {
 
 func getRating(index int) sql.NullInt64 {
 	rating := index % 6
-	return sql.NullInt64{Int64: int64(rating), Valid: rating > 0}
+	return sql.NullInt64{Int64: int64(rating * 20), Valid: rating > 0}
 }
 
 func getIntPtr(r sql.NullInt64) *int {
@@ -967,11 +967,18 @@ func makeScene(i int) *models.Scene {
 		}
 	}
 
+	rating100 := getRating(i)
+	rating5 := rating100
+	if rating5.Valid {
+		rating5.Int64 = int64(models.Rating100To5(int(rating5.Int64)))
+	}
+
 	return &models.Scene{
 		Title:        title,
 		Details:      details,
 		URL:          getSceneEmptyString(i, urlField),
-		Rating:       getIntPtr(getRating(i)),
+		Rating100:    getIntPtr(rating100),
+		Rating:       getIntPtr(rating5),
 		OCounter:     getOCounter(i),
 		Date:         getObjectDateObject(i),
 		StudioID:     studioID,

--- a/ui/v2.5/src/components/Scenes/SceneDetails/RatingSystem.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/RatingSystem.tsx
@@ -331,9 +331,6 @@ export const RatingSystem: React.FC<IRatingSystemProps> = (
         />
       );
       break;
-    case GQL.RatingSystem.None:
-      return <></>;
-      break;
     default:
       toReturn = getRatingStars(5, 1);
       break;

--- a/ui/v2.5/src/core/enums.ts
+++ b/ui/v2.5/src/core/enums.ts
@@ -50,5 +50,4 @@ export const ratingSystemIntlMap = new Map<RatingSystem, string>([
     RatingSystem.TenPointDecimal,
     "config.ui.editing.rating_system.options.ten_point_decimal",
   ],
-  [RatingSystem.None, "config.ui.editing.rating_system.options.none"],
 ]);


### PR DESCRIPTION
This serves to get you started on the backend implementation of translation between the legacy 1-5 rating system, and the 1-100 rating system.

This covers _most_ of the required work for _scenes only_. It doesn't include the necessary changes to the UI to use the `rating100` field instead of `rating`. Testing was done using the graphql playground.

The `None` rating system was removed because I thought I'd need to translate between rating systems, so it's just a superfluous (but wanted) change.

My suggestion for implementation would be to first implement the front-end changes for scene (if it's possible to do it just for scene), then apply the changes, one commit at a time, for image, gallery, movie and performer.